### PR TITLE
Fix bug with some deleted items in child views

### DIFF
--- a/src/java/com/aap/gitst/Utils.java
+++ b/src/java/com/aap/gitst/Utils.java
@@ -19,6 +19,7 @@ import com.starbase.starteam.CheckoutListener;
 import com.starbase.starteam.CheckoutManager;
 import com.starbase.starteam.Item;
 import com.starbase.starteam.ItemList;
+import com.starbase.util.OLEDate;
 
 /**
  * @author Andrey Pavlenko
@@ -95,8 +96,11 @@ public class Utils {
             // FIXME: this is a workaround to avoid unexpected failures during
             // checkout of deleted files.
             try {
-                final com.starbase.starteam.View historyView = repo.getView(i
-                        .getModifiedTime());
+                OLEDate asOfTime = i.getModifiedTime();
+                OLEDate viewCreateTime = repo.getView().getCreatedTime();
+                if (asOfTime.getDoubleValue() < viewCreateTime.getDoubleValue())
+                    asOfTime = viewCreateTime;
+                final com.starbase.starteam.View historyView = repo.getView(asOfTime);
                 final com.starbase.starteam.Item historyItem = historyView
                         .findItem(i.getType(), i.getID());
 


### PR DESCRIPTION
A workaround to deal with failures when checking out deleted items by using a previous view configuration to get the history does not work reliably in child views because the modify time of the item may occur prior to creation of the view itself.  This commit fixes that problem by using the child view's original configuration when this occurs.
